### PR TITLE
ignore OSX’s .DS_Store files

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -61,7 +61,12 @@ function Persistence (options) {
 
   if (this.syncModifications) {
     this.watcher = chokidar.watch(this.directoryName, {ignorePermissionErrors: true});
-    this.watcher.on('all', function () {
+    this.watcher.on('all', function (eventName, filePath) {
+      // ignore OSX .DS_Store files
+      if (path.basename(filePath) === '.DS_Store') {
+        return;
+      }
+
       if (Math.abs(new Date() - self.lastChange) > self.treshold) {
         self.loadDatabase(function () {
           self.emit('external-modification');
@@ -353,6 +358,11 @@ Persistence.prototype.loadDatabase = function (cb) {
     var docs = [];
     var docsById = {};
     async.each(files, function (d, cb) {
+      // ignore OSX .DS_Store files
+      if (d === '.DS_Store') {
+        return cb();
+      }
+
       self.parseEntryDirectory(path.join(self.directoryName, d), function (err, doc) {
         if (err) {
           return callback(err);

--- a/test/persistenceTest.js
+++ b/test/persistenceTest.js
@@ -373,6 +373,40 @@ describe('persistence', function () {
     })
   })
 
+  it('loadDatabase should ignore OSX .DS_Store files in templates path', function (done) {
+    fs.writeFileSync(path.join(templatesPath, '.DS_Store'), 'test content')
+
+    persistence.loadDatabase(function (err) {
+      if (err) {
+        return done(err)
+      }
+
+      done()
+    })
+  })
+
+  it('loadDatabase should ignore OSX .DS_Store files in template directory', function (done) {
+    persistence.persistNewState([{
+      name: 'name',
+      html: 'content',
+      _id: 'id'
+    }], function (err) {
+      if (err) {
+        return done(err)
+      }
+
+      fs.writeFileSync(path.join(templatesPath, 'name', '.DS_Store'), 'test content')
+
+      persistence.loadDatabase(function (err) {
+        if (err) {
+          return done(err)
+        }
+
+        done()
+      })
+    })
+  })
+
   function deleteFilesSync (path) {
     try {
       var files = fs.readdirSync(path)


### PR DESCRIPTION
sometimes OSX creates a `.DS_Store` file when using a folder and because of that jsreport complaints that the database is corrupted (because it can't find `.DS_Store/config.json` ...), this PR ignore `.DS_Store` files when loading the database and when listen for external changes.