### PR TITLE
update chokidar initialization

### DIFF
--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -40,6 +40,9 @@ function Persistence (options) {
   this.resolveFileExtension = options.resolveFileExtension;
   this.syncModifications = options.syncModifications == null ? true : options.syncModifications;
   this.treshold = 500;
+
+  var readyToListenForChanges = false;
+
   var keys = Object.keys(this.entityType).filter(function (k) {
     return self.entityType[k].publicKey;
   });
@@ -60,8 +63,17 @@ function Persistence (options) {
   this.lastChange = new Date();
 
   if (this.syncModifications) {
-    this.watcher = chokidar.watch(this.directoryName, {ignorePermissionErrors: true});
+    this.watcher = chokidar.watch(this.directoryName, {ignorePermissionErrors: true, ignoreInitial: true});
+
+    this.watcher.on('ready', function() {
+      readyToListenForChanges = true;
+    });
+
     this.watcher.on('all', function (eventName, filePath) {
+      if (!readyToListenForChanges) {
+        return;
+      }
+
       // ignore OSX .DS_Store files
       if (path.basename(filePath) === '.DS_Store') {
         return;
@@ -72,6 +84,10 @@ function Persistence (options) {
           self.emit('external-modification');
         });
       }
+    });
+
+    self.loadDatabase(function () {
+      self.emit('external-modification');
     });
   } else {
     self.loadDatabase(function() {});

--- a/lib/persistence.js
+++ b/lib/persistence.js
@@ -85,12 +85,6 @@ function Persistence (options) {
         });
       }
     });
-
-    self.loadDatabase(function () {
-      self.emit('external-modification');
-    });
-  } else {
-    self.loadDatabase(function() {});
   }
 }
 

--- a/test/persistenceTest.js
+++ b/test/persistenceTest.js
@@ -45,7 +45,7 @@ describe('persistence', function () {
   })
 
   afterEach(function () {
-    persistence.watcher.close()
+    persistence.watcher && persistence.watcher.close()
   })
 
   it('should work on empty database', function (done) {


### PR DESCRIPTION
this PR updates chokidar initialization to take into account external modifications after the first scan.

i had noticed that on jsreport's start the chokidar's `all` event is called everytime for each file it detects during initialization, causing that the database is re-loaded multiple times needlessly.

The curious part after this change is that some tests are failing, seems to me that there is some kind of race condition, or some part of the code expects to re-load the database everytime on initialization to work propertly?

so i decided to test the current test suite **without this PR** but with `syncModifications` option set to `false`

```js
beforeEach(function () {
    deleteFilesSync(dataPath)

    db = new Datastore({
      filename: path.join(dataPath, 'templates'),
      autoload: false, inMemoryOnly: false
    })
    persistence = new Persistence({
      db: db,
      model: model,
      entitySetName: 'templates',
      entityType: model.entityTypes.TemplateType,
      resolveFileExtension: function (doc, entitySetName, entityType, propType) {
        return propType.document.extension
      },
      // NEW LINE HEREEEEE.....
      syncModifications: false
    })
  })

  afterEach(function () {
    // UPDATED LINE HEREEEEE.....
    persistence.watcher && persistence.watcher.close()
  })
```

and surprisingly the same tests are failing:

<img width="721" alt="captura de pantalla 2016-11-20 a las 7 17 43 p m" src="https://cloud.githubusercontent.com/assets/4262050/20467450/0c0b7ab2-af56-11e6-9df2-13a326a14fdb.png">


Do you know why this happens? , maybe there is some part of the code that expects the re-load of the database every time?



